### PR TITLE
Change feching sequence

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -35,6 +35,7 @@ async function extractLobbyLink(postId) {
     
     // steam://joinlobby 직접 링크 찾기
     const lobbyMatch = html.match(/steam:\/\/joinlobby\/\d+\/\d+/);
+    // console.log(`[SEAF] 로비 링크 추출 시도 (${postId}):`, lobbyMatch[0]);
     if (lobbyMatch) {
       return lobbyMatch[0];
     }
@@ -167,6 +168,11 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === "RESET_LAST_ID") {
+    console.log(`[SEAF] lastSeenPostId 초기화됨`);
+    lastSeenPostId = null;
+  }
+
   if (request.type === "SETTINGS_UPDATED") {
     setupAlarm();
   }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -34,7 +34,7 @@ async function extractLobbyLink(postId) {
     const html = await response.text();
     
     // steam://joinlobby 직접 링크 찾기
-    const lobbyMatch = html.match(/steam:\/\/joinlobby\/\d+\/\d+\/\d+/);
+    const lobbyMatch = html.match(/steam:\/\/joinlobby\/\d+\/\d+/);
     if (lobbyMatch) {
       return lobbyMatch[0];
     }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -236,10 +236,10 @@ const SEAF_CONTENT = {
    * 초기화
    */
   init: function() {
-    // 주입 시 background.js의 lastSeenPostd를 초기화
-    if (this.isListPage()) {
-      chrome.runtime.sendMessage({ type: "RESET_LAST_ID" });
-    }
+    // // 주입 시 background.js의 lastSeenPostd를 초기화
+    // if (this.isListPage()) {
+    //   chrome.runtime.sendMessage({ type: "RESET_LAST_ID" });
+    // }
     // 목록 페이지
     if (this.isListPage() || this.isViewPage()) {
       this.enhanceListPage();

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -236,9 +236,14 @@ const SEAF_CONTENT = {
    * 초기화
    */
   init: function() {
+    // 주입 시 background.js의 lastSeenPostd를 초기화
+    if (this.isListPage()) {
+      chrome.runtime.sendMessage({ type: "RESET_LAST_ID" });
+    }
     // 목록 페이지
     if (this.isListPage() || this.isViewPage()) {
       this.enhanceListPage();
+      // NOTE: MutationObserver는 dcinside에서 작동하지 않을 것으로 보임. 호환성을 위해 삭제하지 않았음
       new MutationObserver(() => this.enhanceListPage())
         .observe(document.body, { childList: true, subtree: true });
     }


### PR DESCRIPTION
#1 

# 개요
Issue #1 의 내용을 적용한 수정입니다.
## 큰 변경점은 다음과 같습니다
- 탐색 주기 중 새 글들을 탐지했을 때 각 게시글들에 대해 extractLobbyLink를 호출하지 않음
- content.js init 시 글 목록의 게시글들에 대해 extractLobbyLink를 호출하지 않음
- 토스트 및 글 목록의 참가 버튼을 누르면 extractLobbyLink를 호출하도록 변경
- ~content.js init 시 lastSeenPostId를 초기화하는 로직 추가~
- 새 글을 추출하는 로직에서 fliter 수정
- steamlobby 링크 추출 정규식 버그 수정

## 이 변경점의 의도는 다음과 같습니다
- 탐색 주기 과정에서 lazy fetching을 통해 불필요한 fetch를 전부 제거
- 게시글에 참가 버튼을 다는 과정에서 lazy fetching을 통해 불필요한 fetch를 전부 제거

## 이로 인한 개선점은 다음과 같습니다
1. 코너 케이스에서 폭발적인 feching으로 IP밴을 당하는 가능성 제거
2. 불필요한 fetching을 제거해 네트워크 사용량 감소
3. 일부 steamlobby link를 추출하지 못하는 버그 수정
4. 일부 시나리오에서 폭발적인 토스트 알림이 뜨는 문제 해결

# Note
- extractLobbyLink 함수에서 불필요한 폴백 로직 제거
- createToast의 인자는 호환성을 위해 변경하지 않았음
- 일부 로그 코드 변경